### PR TITLE
Add export/import for financial data

### DIFF
--- a/lancamentos.html
+++ b/lancamentos.html
@@ -24,6 +24,12 @@
       <div id="monthButtons" class="btn-group flex-wrap"></div>
     </div>
 
+    <div class="mb-3">
+      <button id="exportBtn" class="btn btn-outline-secondary me-2">Exportar</button>
+      <button id="importBtn" class="btn btn-outline-secondary">Importar</button>
+      <input type="file" id="importFile" accept="application/json" class="d-none">
+    </div>
+
     <div class="row g-3">
       <div class="col-lg-9">
         <div id="infoMes" class="row g-3 mb-3 text-center">

--- a/script.js
+++ b/script.js
@@ -7,6 +7,37 @@ function save() {
   localStorage.setItem('financas-v2', JSON.stringify(store));
 }
 
+function exportData() {
+  const blob = new Blob([JSON.stringify(store)], { type: 'application/json' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'financas.json';
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
+function importData(e) {
+  const file = e.target.files && e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = ev => {
+    try {
+      const data = JSON.parse(ev.target.result);
+      if (data && data.years && data.recurring) {
+        store = data;
+        save();
+        render();
+      } else {
+        alert('Arquivo inválido');
+      }
+    } catch (err) {
+      alert('Erro ao importar');
+    }
+  };
+  reader.readAsText(file);
+  e.target.value = '';
+}
+
 function getYearData(y) {
   if(!store.years[y]) store.years[y] = {};
   return store.years[y];
@@ -272,14 +303,25 @@ function togglePaid(e) {
 function init() {
   renderYearSelect();
   renderMonthButtons();
-  document.getElementById('transactionForm').addEventListener('submit', addTransaction);
-  document.getElementById('initialBalance').addEventListener('input', e=>{
+  const form = document.getElementById('transactionForm');
+  if (form) form.addEventListener('submit', addTransaction);
+  const balanceInput = document.getElementById('initialBalance');
+  if (balanceInput) balanceInput.addEventListener('input', e=>{
     const data = getMonthData(currentYear, currentMonth);
     data.initialBalance = parseFloat(e.target.value)||0;
     save();
     render();
   });
-  document.getElementById('payment').addEventListener('change', handlePaymentChange);
+  const paymentSelect = document.getElementById('payment');
+  if (paymentSelect) paymentSelect.addEventListener('change', handlePaymentChange);
+  const exportBtn = document.getElementById('exportBtn');
+  if (exportBtn) exportBtn.addEventListener('click', exportData);
+  const importBtn = document.getElementById('importBtn');
+  const importFile = document.getElementById('importFile');
+  if (importBtn && importFile) {
+    importBtn.addEventListener('click', () => importFile.click());
+    importFile.addEventListener('change', importData);
+  }
   handlePaymentChange();
   render();
 }


### PR DESCRIPTION
## Summary
- add buttons to export and import JSON backup of finances
- implement export/import helpers saving to localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c0c12d21c832191fb385838c9d40d