### PR TITLE
Postpone credit card charges to next month

### DIFF
--- a/script.js
+++ b/script.js
@@ -207,7 +207,7 @@ function addTransaction(e) {
     for(let i=0;i<parcelas;i++) {
       const valor = i === parcelas-1 ? restante : base;
       restante -= base;
-      const d = addMonths(form.date.value, i);
+      const d = addMonths(form.date.value, i + 1);
       const dateStr = d.toISOString().split('T')[0];
       const t = {
         id: Date.now()+i,


### PR DESCRIPTION
## Summary
- ensure credit card purchases are recorded starting in the month after the purchase date

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688c0fee5f548321abac35fb8c0ed85e