### PR TITLE
Implement budget management page and layout demo

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -128,3 +128,10 @@ export function renderMonthButtons(render){
     container.appendChild(btn);
   });
 }
+
+export function getBudgetData(year, month){
+  const yearData = getYearData(year);
+  if(!yearData.budgets) yearData.budgets = {};
+  if(!yearData.budgets[month]) yearData.budgets[month] = [];
+  return yearData.budgets[month];
+}

--- a/js/lancamentos.js
+++ b/js/lancamentos.js
@@ -1,4 +1,4 @@
-import { currentYear, currentMonth, store, save, exportData, importData, getMonthData, renderYearSelect, renderMonthButtons, formatMoney, setText, addMonths } from './common.js';
+import { currentYear, currentMonth, store, save, exportData, importData, getMonthData, getBudgetData, renderYearSelect, renderMonthButtons, formatMoney, setText, addMonths } from './common.js';
 
 let editing = null;
 
@@ -67,7 +67,7 @@ function recalc(){
   setText('saldoPrevisto', formatMoney(saldoPrevisto));
 
   const gastos = despesas + investimentos;
-  const budget = receitas || 1;
+  const budget = getBudgetData(currentYear, currentMonth).reduce((sum, b) => sum + Number(b.amount), 0) || 1;
   const percent = Math.min(100, (gastos / budget) * 100);
   const bar = document.getElementById('budgetProgress');
   if (bar) {

--- a/js/orcamento.js
+++ b/js/orcamento.js
@@ -1,0 +1,68 @@
+import { currentYear, currentMonth, save, getMonthData, getBudgetData, renderYearSelect, renderMonthButtons, formatMoney } from './common.js';
+
+function render(){
+  renderYearSelect(render);
+  renderMonthButtons(render);
+  renderTable();
+}
+
+function renderTable(){
+  const tbody = document.querySelector('#budgetTable tbody');
+  if(!tbody) return;
+  tbody.innerHTML = '';
+  const budgets = getBudgetData(currentYear, currentMonth);
+  const transactions = getMonthData(currentYear, currentMonth).transactions;
+  budgets.forEach(b => {
+    const gasto = transactions.filter(t => t.category === b.category && (t.subcategory || '') === (b.subcategory || ''))
+      .reduce((sum, t) => sum + Number(t.value), 0);
+    const percent = b.amount ? Math.min(100, (gasto / b.amount) * 100) : 0;
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${b.category}</td>
+      <td>${b.subcategory || ''}</td>
+      <td>${formatMoney(b.amount)}</td>
+      <td>
+        <div class="progress">
+          <div class="progress-bar ${percent>=100?'bg-danger':''}" style="width:${percent}%">
+            ${formatMoney(gasto)}
+          </div>
+        </div>
+      </td>
+      <td><button class="btn btn-sm btn-outline-danger delete-btn" data-id="${b.id}"><i class="bi bi-trash"></i></button></td>
+    `;
+    tbody.appendChild(tr);
+  });
+  tbody.querySelectorAll('.delete-btn').forEach(btn => btn.addEventListener('click', deleteBudget));
+}
+
+function addBudget(e){
+  e.preventDefault();
+  const form = e.target;
+  const budgets = getBudgetData(currentYear, currentMonth);
+  budgets.push({
+    id: Date.now(),
+    category: form.category.value,
+    subcategory: form.subcategory.value,
+    amount: parseFloat(form.amount.value) || 0
+  });
+  save();
+  form.reset();
+  renderTable();
+}
+
+function deleteBudget(e){
+  const id = Number(e.target.closest('button').dataset.id);
+  const budgets = getBudgetData(currentYear, currentMonth);
+  const idx = budgets.findIndex(b => b.id === id);
+  if(idx >= 0){
+    budgets.splice(idx,1);
+    save();
+    renderTable();
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  render();
+  const form = document.getElementById('budgetForm');
+  if(form) form.addEventListener('submit', addBudget);
+});

--- a/layout.html
+++ b/layout.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Layout Moderno</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    .hero {
+      background: linear-gradient(135deg,#0d6efd,#6610f2);
+      color: #fff;
+      padding: 4rem 1rem;
+      text-align: center;
+      border-radius: .5rem;
+    }
+    .feature-icon {
+      font-size: 2rem;
+      color: var(--bs-primary);
+    }
+  </style>
+</head>
+<body class="bg-light">
+  <div class="container py-5">
+    <div class="hero mb-4">
+      <h1 class="display-5">Exemplo de Layout Moderno</h1>
+      <p class="lead">Demonstração de componentes Bootstrap com estilo customizado.</p>
+    </div>
+    <div class="row g-4">
+      <div class="col-md-4">
+        <div class="card h-100 shadow-sm">
+          <div class="card-body text-center">
+            <i class="bi bi-speedometer2 feature-icon"></i>
+            <h5 class="card-title mt-3">Rápido</h5>
+            <p class="card-text">Interface responsiva com Bootstrap 5.</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card h-100 shadow-sm">
+          <div class="card-body text-center">
+            <i class="bi bi-palette feature-icon"></i>
+            <h5 class="card-title mt-3">Moderno</h5>
+            <p class="card-text">Uso de cores vibrantes e ícones.</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card h-100 shadow-sm">
+          <div class="card-body text-center">
+            <i class="bi bi-phone feature-icon"></i>
+            <h5 class="card-title mt-3">Responsivo</h5>
+            <p class="card-text">Adapta-se a diferentes tamanhos de tela.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/orcamento.html
+++ b/orcamento.html
@@ -16,10 +16,46 @@
       <li class="nav-item"><a class="nav-link" href="lancamentos.html">Lançamentos</a></li>
     </ul>
 
-    <div class="p-4 bg-white rounded shadow-sm">
-      <h1 class="h4">Orçamento</h1>
-      <p>Página para definição de orçamentos.</p>
+    <div class="d-flex mb-3">
+      <select id="yearSelect" class="form-select w-auto me-2"></select>
+      <div id="monthButtons" class="btn-group flex-wrap"></div>
+    </div>
+
+    <form id="budgetForm" class="row g-2 mb-3">
+      <div class="col-md-3">
+        <select id="category" name="category" class="form-select">
+          <option>Despesa</option>
+          <option>Investimento</option>
+          <option>Receita</option>
+        </select>
+      </div>
+      <div class="col-md-4">
+        <input type="text" id="subcategory" name="subcategory" class="form-control" placeholder="Subcategoria">
+      </div>
+      <div class="col-md-3">
+        <input type="number" id="amount" name="amount" class="form-control" placeholder="Valor" step="0.01" required>
+      </div>
+      <div class="col-md-2">
+        <button type="submit" class="btn btn-primary w-100">Adicionar</button>
+      </div>
+    </form>
+
+    <div class="table-container">
+      <table id="budgetTable" class="table table-striped table-hover">
+        <thead class="table-light">
+          <tr>
+            <th>Categoria</th>
+            <th>Subcategoria</th>
+            <th>Orçado</th>
+            <th>Gasto</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
     </div>
   </div>
+
+  <script type="module" src="js/orcamento.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `getBudgetData` helper and integrate budget totals with spending progress
- create interactive `orcamento` page to manage category budgets per month
- include standalone modern layout demo page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/orcamento.js js/lancamentos.js js/common.js`


------
https://chatgpt.com/codex/tasks/task_e_6896b1846b6c8321b93969082b6964b0